### PR TITLE
Adjust the namespace to include `Storage`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Supabase\\Test\\": "tests/"
+            "Supabase\\Storage\\Test\\": "tests/"
         }
     },
     "authors": [

--- a/src/StorageBucket.php
+++ b/src/StorageBucket.php
@@ -9,8 +9,8 @@
 namespace Supabase\Storage;
 
 use Psr\Http\Message\ResponseInterface;
-use Supabase\Util\Constants;
-use Supabase\Util\Request;
+use Supabase\Storage\Util\Constants;
+use Supabase\Storage\Util\Request;
 
 class StorageBucket extends StorageFile
 {

--- a/src/StorageClient.php
+++ b/src/StorageClient.php
@@ -4,6 +4,13 @@ namespace Supabase\Storage;
 
 class StorageClient extends StorageBucket
 {
+
+	private mixed $domain;
+	private mixed $scheme;
+	private mixed $path;
+	private mixed $api_key;
+	private mixed $reference_id;
+
 	/**
 	 * StorageClient constructor.
 	 *

--- a/src/StorageClient.php
+++ b/src/StorageClient.php
@@ -4,7 +4,6 @@ namespace Supabase\Storage;
 
 class StorageClient extends StorageBucket
 {
-
 	private mixed $domain;
 	private mixed $scheme;
 	private mixed $path;

--- a/src/StorageFile.php
+++ b/src/StorageFile.php
@@ -11,9 +11,9 @@ namespace Supabase\Storage;
 use Bayfront\MimeTypes\MimeType;
 use League\Uri\Http;
 use Psr\Http\Message\ResponseInterface;
-use Supabase\Util\Constants;
-use Supabase\Util\FileHandler;
-use Supabase\Util\Request;
+use Supabase\Storage\Util\Constants;
+use Supabase\Storage\Util\FileHandler;
+use Supabase\Storage\Util\Request;
 
 class StorageFile
 {

--- a/src/Util/Constants.php
+++ b/src/Util/Constants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 class Constants
 {

--- a/src/Util/EnvSetup.php
+++ b/src/Util/EnvSetup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 use Dotenv\Dotenv;
 

--- a/src/Util/EnvSetup.php
+++ b/src/Util/EnvSetup.php
@@ -25,11 +25,11 @@ class EnvSetup
 		}
 
 		if (empty($apiKey)) {
-			throw new \Exception('Could not loaded API_KEY');
+			throw new \Exception('Could not load API_KEY');
 		}
 
 		if (empty($refId)) {
-			throw new \Exception('Could not loaded API_KEY');
+			throw new \Exception('Could not load REFERENCE_ID');
 		}
 
 		return [

--- a/src/Util/EnvSetup.php
+++ b/src/Util/EnvSetup.php
@@ -25,11 +25,11 @@ class EnvSetup
 		}
 
 		if (empty($apiKey)) {
-			throw new Exception('Could not loade API_KEY');
+			throw new \Exception('Could not loaded API_KEY');
 		}
 
 		if (empty($refId)) {
-			throw new Exception('Could not loade API_KEY');
+			throw new \Exception('Could not loaded API_KEY');
 		}
 
 		return [

--- a/src/Util/EnvSetup.php
+++ b/src/Util/EnvSetup.php
@@ -25,11 +25,11 @@ class EnvSetup
 		}
 
 		if (empty($apiKey)) {
-			throw new Error('Could not loade API_KEY');
+			throw new Exception('Could not loade API_KEY');
 		}
 
 		if (empty($refId)) {
-			throw new Error('Could not loade API_KEY');
+			throw new Exception('Could not loade API_KEY');
 		}
 
 		return [

--- a/src/Util/FileHandler.php
+++ b/src/Util/FileHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 class FileHandler
 {

--- a/src/Util/Request.php
+++ b/src/Util/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Util/StorageApiError.php
+++ b/src/Util/StorageApiError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 class StorageApiError extends StorageError
 {

--- a/src/Util/StorageError.php
+++ b/src/Util/StorageError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 class StorageError extends \Exception
 {

--- a/src/Util/StorageUnknownError.php
+++ b/src/Util/StorageUnknownError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Supabase\Util;
+namespace Supabase\Storage\Util;
 
 class StorageUnknownError extends StorageError
 {

--- a/tests/integration/StorageBucketTest.php
+++ b/tests/integration/StorageBucketTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use Supabase\Util\EnvSetup;
+use Supabase\Storage\Util\EnvSetup;
 
 final class StorageBucketTest extends TestCase
 {

--- a/tests/integration/StorageFileTest.php
+++ b/tests/integration/StorageFileTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use Supabase\Util\EnvSetup;
+use Supabase\Storage\Util\EnvSetup;
 
 final class StorageFileTest extends TestCase
 {

--- a/tests/unit/BucketTest.php
+++ b/tests/unit/BucketTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Supabase\Storage\StorageClient;
 
 class BucketTest extends TestCase
 {
@@ -19,7 +20,7 @@ class BucketTest extends TestCase
 	 */
 	public function testNewStorageClient()
 	{
-		$client = new  \Supabase\Storage\StorageClient('somekey', 'some_ref_id');
+		$client = new  StorageClient('somekey', 'some_ref_id');
 		$this->assertEquals($client->__getUrl(), 'https://some_ref_id.supabase.co/storage/v1');
 		$this->assertEquals($client->__getHeaders(), [
 			'X-Client-Info' => 'storage-php/0.0.1',

--- a/tests/unit/FileTest.php
+++ b/tests/unit/FileTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Supabase\Storage\StorageFile;
 
 class FileTest extends TestCase
 {
@@ -17,7 +18,7 @@ class FileTest extends TestCase
 	 */
 	public function testNewStorageFile()
 	{
-		$client = new  \Supabase\Storage\StorageFile('somekey', 'some_ref_id', 'someBucket');
+		$client = new StorageFile('somekey', 'some_ref_id', 'someBucket');
 		$this->assertEquals($client->__getUrl(), 'https://some_ref_id.supabase.co/storage/v1');
 		$this->assertEquals($client->__getHeaders(), [
 			'X-Client-Info' => 'storage-php/0.0.1',
@@ -61,7 +62,7 @@ class FileTest extends TestCase
 	 */
 	public function testUpload()
 	{
-		$mockFile = \Mockery::mock('alias:Supabase\Util\FileHandler');
+		$mockFile = \Mockery::mock('alias:Supabase\Storage\Util\FileHandler');
 		$mockFile->shouldReceive('getFileContents')->andReturn('Bruno Estera');
 
 		$mock = \Mockery::mock(
@@ -124,7 +125,7 @@ class FileTest extends TestCase
 	 */
 	public function testUpdate()
 	{
-		$mockFile = \Mockery::mock('alias:Supabase\Util\FileHandler');
+		$mockFile = \Mockery::mock('alias:Supabase\Storage\Util\FileHandler');
 		$mockFile->shouldReceive('getFileContents')->andReturn('Isla Ian');
 
 		$mock = \Mockery::mock(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adjusting the package's namespace from `Supabase\Util\Constants` to `Supabase\Storage\Util\Constants` for all cases. Fixing issues with error handling when loading `.env` vars from tests and examples.