### PR TITLE
Allow using fresh composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,6 @@
         "guzzlehttp/guzzle": "^7.5",
         "vlucas/phpdotenv": "^5.5",
         "bayfrontmedia/php-mime-types": "^2.0",
-        "league/uri": "^6.0"
+        "league/uri": "^6.0 || ^7.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "mockery/mockery": "^1.5"
     },
     "require": {
-        "guzzlehttp/guzzle": "7.5",
-        "vlucas/phpdotenv": "5.5",
+        "guzzlehttp/guzzle": "^7.5",
+        "vlucas/phpdotenv": "^5.5",
         "bayfrontmedia/php-mime-types": "^2.0",
         "league/uri": "^6.0"
     }


### PR DESCRIPTION
This is a simple fix for composer dependencies (non-dev ones): instead of locked versions of `guzzlehttp/guzzle`, `vlucas/phpdotenv` and `league/uri`, I propose to allow using fresher ones.

Additionally, the next major version of the `league/uri` ca be used as this package doesn't use any functionality from the `league/uri` that is removed in a new version or marked as BC break: https://github.com/thephpleague/uri/releases/tag/7.0.0 (it's important as `league/uri` v6 can't b installed with PHP 8.3